### PR TITLE
feat: [Hobby] open api DB 저장, DB data 프론트 반환 API

### DIFF
--- a/src/main/java/com/reborn/server/domain/hobby/api/HobbyApi.java
+++ b/src/main/java/com/reborn/server/domain/hobby/api/HobbyApi.java
@@ -1,0 +1,13 @@
+package com.reborn.server.domain.hobby.api;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/hobbies")
+@RequiredArgsConstructor
+@Tag(name = "Hobby", description = "Hobby API")
+public class HobbyApi {
+}

--- a/src/main/java/com/reborn/server/domain/hobby/api/HobbyApi.java
+++ b/src/main/java/com/reborn/server/domain/hobby/api/HobbyApi.java
@@ -1,13 +1,25 @@
 package com.reborn.server.domain.hobby.api;
 
+import com.reborn.server.domain.hobby.application.HobbyService;
+import com.reborn.server.domain.hobby.dto.response.HobbyResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/hobbies")
 @RequiredArgsConstructor
 @Tag(name = "Hobby", description = "Hobby API")
 public class HobbyApi {
+
+    private final HobbyService hobbyService;
+
+    @GetMapping() // "/hobbies" 경로로 GET 요청 시 호출
+    public List<HobbyResponse> getHobbies() {
+        return hobbyService.getAllHobbies(); // 서비스에서 데이터 가져와 반환
+    }
 }

--- a/src/main/java/com/reborn/server/domain/hobby/application/HobbyService.java
+++ b/src/main/java/com/reborn/server/domain/hobby/application/HobbyService.java
@@ -1,0 +1,79 @@
+package com.reborn.server.domain.hobby.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reborn.server.domain.hobby.dao.HobbyRepository;
+import com.reborn.server.domain.hobby.domain.Hobby;
+import com.reborn.server.domain.hobby.dto.HobbyDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HobbyService {
+
+    private final HobbyRepository hobbyRepository;
+
+    public List<Hobby> saveHobbies(List<HobbyDto> hobbyDtoList) {
+        List<Hobby> savedHobbies = new ArrayList<>();
+
+        for (HobbyDto hobbyDto : hobbyDtoList) {
+            Hobby hobby = Hobby.from(hobbyDto);
+            try {
+                // 데이터베이스에 저장
+                savedHobbies.add(hobbyRepository.save(hobby)); // 여기에서 유니크 제약으로 예외 발생 가능
+            } catch (DataIntegrityViolationException e) {
+                // 중복된 classTitle로 인한 예외 처리
+                System.out.println("Hobby with title '" + hobbyDto.getClassTitle() + "' already exists. Skipping.");
+            }
+        }
+
+        System.out.println(savedHobbies.size());
+        return savedHobbies; // 성공적으로 저장된 Hobby 객체 반환
+    }
+
+    public int parseHobbyDtosAndSave(String jsonResponse) {
+        List<HobbyDto> hobbyDtoList = new ArrayList<>();
+        ObjectMapper objectMapper = new ObjectMapper();
+        int currentCount = 0;
+
+        try {
+            // JSON 문자열을 JsonNode로 변환
+            JsonNode rootNode = objectMapper.readTree(jsonResponse);
+            JsonNode dataNode = rootNode.path("data"); // "data" 배열 추출
+            JsonNode countNode = rootNode.path("currentCount");
+            System.out.println("currentCount: " + countNode.asText());
+            currentCount = countNode.asInt();
+
+            // data 배열을 순회하여 HobbyDto 생성
+            for (JsonNode hobbyNode : dataNode) {
+                HobbyDto hobbyDto = HobbyDto.of(
+                        hobbyNode.path("법정읍면동명칭").asText(),
+                        hobbyNode.path("시군구 명칭").asText(),
+                        hobbyNode.path("시군구 주소").asText(),
+                        hobbyNode.path("시도 명칭").asText(),
+                        hobbyNode.path("최종작성일").asText(),
+                        hobbyNode.path("카테고리3").asText(),
+                        hobbyNode.path("클래스 시간").asInt(),
+                        hobbyNode.path("클래스 요금").asInt(),
+                        hobbyNode.path("클래스 인원").asText(),
+                        hobbyNode.path("클래스 커리큘럼").asText(),
+                        hobbyNode.path("클래스 타이틀").asText()
+                );
+                hobbyDtoList.add(hobbyDto);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        // 결과 출력 test
+        for (HobbyDto hobbyDto : hobbyDtoList) {
+            System.out.println(hobbyDto.getClassTitle());
+        }
+        saveHobbies(hobbyDtoList);
+        return currentCount;
+    }
+}

--- a/src/main/java/com/reborn/server/domain/hobby/application/HobbyService.java
+++ b/src/main/java/com/reborn/server/domain/hobby/application/HobbyService.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.reborn.server.domain.hobby.dao.HobbyRepository;
 import com.reborn.server.domain.hobby.domain.Hobby;
 import com.reborn.server.domain.hobby.dto.HobbyDto;
+import com.reborn.server.domain.hobby.dto.response.HobbyResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -70,5 +72,13 @@ public class HobbyService {
         }
         saveHobbies(hobbyDtoList);
         return currentCount;
+    }
+
+    public List<HobbyResponse> getAllHobbies() {
+        List<Hobby> hobbies = hobbyRepository.findAll();
+
+        return hobbies.stream()
+                .map(hobby -> new HobbyResponse(hobby.getId(), hobby.getCityDistrictName(), hobby.getProvinceName(), hobby.getCategory(), hobby.getClassDuration(), hobby.getTotalCost(), hobby.getClassParticipants(), hobby.getCurriculum(), hobby.getClassTitle())) // DTO로 변환
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/reborn/server/domain/hobby/application/HobbyService.java
+++ b/src/main/java/com/reborn/server/domain/hobby/application/HobbyService.java
@@ -46,7 +46,6 @@ public class HobbyService {
             JsonNode rootNode = objectMapper.readTree(jsonResponse);
             JsonNode dataNode = rootNode.path("data"); // "data" 배열 추출
             JsonNode countNode = rootNode.path("currentCount");
-            System.out.println("currentCount: " + countNode.asText());
             currentCount = countNode.asInt();
 
             // data 배열을 순회하여 HobbyDto 생성
@@ -68,10 +67,6 @@ public class HobbyService {
             }
         } catch (Exception e) {
             e.printStackTrace();
-        }
-        // 결과 출력 test
-        for (HobbyDto hobbyDto : hobbyDtoList) {
-            System.out.println(hobbyDto.getClassTitle());
         }
         saveHobbies(hobbyDtoList);
         return currentCount;

--- a/src/main/java/com/reborn/server/domain/hobby/dao/HobbyRepository.java
+++ b/src/main/java/com/reborn/server/domain/hobby/dao/HobbyRepository.java
@@ -1,0 +1,10 @@
+package com.reborn.server.domain.hobby.dao;
+
+import com.reborn.server.domain.hobby.domain.Hobby;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HobbyRepository extends JpaRepository<Hobby, Long> {
+    Optional<Hobby> findByClassTitle(String classTitle);
+}

--- a/src/main/java/com/reborn/server/domain/hobby/domain/Hobby.java
+++ b/src/main/java/com/reborn/server/domain/hobby/domain/Hobby.java
@@ -1,0 +1,82 @@
+package com.reborn.server.domain.hobby.domain;
+
+import com.reborn.server.domain.hobby.dto.HobbyDto;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hobby {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String legalTownName; // 법정읍면동명칭
+    private String cityDistrictName; // 시군구 명칭
+    private String cityDistrictAddress; // 시군구 주소
+    private String provinceName; // 시도 명칭
+    private String lastUpdatedDate; // 최종작성일
+    private String category; // 카테고리
+    private int classDuration; // 클래스 시간
+    private int totalCost; // 클래스 요금
+    private String classParticipants; // 클래스 인원
+
+    @Column(name = "curriculum", length = 2000)
+    private String curriculum; // 클래스 커리큘럼
+
+    @Column(name = "class_title", unique = true) // classTitle을 유니크로 설정
+    private String classTitle; // 클래스 타이틀
+
+    @Builder
+    public Hobby(String legalTownName, String cityDistrictName, String cityDistrictAddress, String provinceName, String lastUpdatedDate, String category, int classDuration, int totalCost, String classParticipants, String curriculum, String classTitle) {
+        this.legalTownName = legalTownName;
+        this.cityDistrictName = cityDistrictName;
+        this.cityDistrictAddress = cityDistrictAddress;
+        this.provinceName = provinceName;
+        this.lastUpdatedDate = lastUpdatedDate;
+        this.category = category;
+        this.classDuration = classDuration;
+        this.totalCost = totalCost;
+        this.classParticipants = classParticipants;
+        this.curriculum = curriculum;
+        this.classTitle = classTitle;
+    }
+
+    public static Hobby of(String legalTownName, String cityDistrictName, String cityDistrictAddress, String provinceName, String lastUpdatedDate, String category, int classDuration, int totalCost, String classParticipants, String curriculum, String classTitle){
+        return Hobby.builder()
+                .legalTownName(legalTownName)
+                .cityDistrictName(cityDistrictName)
+                .cityDistrictAddress(cityDistrictAddress)
+                .provinceName(provinceName)
+                .lastUpdatedDate(lastUpdatedDate)
+                .category(category)
+                .classDuration(classDuration)
+                .totalCost(totalCost)
+                .classParticipants(classParticipants)
+                .curriculum(curriculum)
+                .classTitle(classTitle)
+                .build();
+    }
+
+    public static Hobby from(HobbyDto hobbyDto){
+        return Hobby.builder()
+                .legalTownName(hobbyDto.getLegalTownName())
+                .cityDistrictName(hobbyDto.getCityDistrictName()) // 시군구 명칭
+                .cityDistrictAddress(hobbyDto.getCityDistrictAddress()) // 시군구 주소
+                .provinceName(hobbyDto.getProvinceName()) // 시도 명칭
+                .lastUpdatedDate(hobbyDto.getLastUpdatedDate()) // 최종작성일
+                .category(hobbyDto.getCategory()) // 여가활동
+                .classDuration(hobbyDto.getClassDuration()) // 클래스 시간
+                .totalCost(hobbyDto.getTotalCost()) // 클래스 요금
+                .classParticipants(hobbyDto.getClassParticipants()) // 클래스 인원
+                .curriculum(hobbyDto.getCurriculum()) // 클래스 커리큘럼
+                .classTitle(hobbyDto.getClassTitle()) // 클래스 타이틀
+                .build(); // 빌드하여 Hobby 객체 생성
+    }
+}

--- a/src/main/java/com/reborn/server/domain/hobby/dto/HobbyDto.java
+++ b/src/main/java/com/reborn/server/domain/hobby/dto/HobbyDto.java
@@ -1,0 +1,41 @@
+package com.reborn.server.domain.hobby.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class HobbyDto {
+
+    private String legalTownName; // 법정읍면동명칭
+    private String cityDistrictName; // 시군구 명칭
+    private String cityDistrictAddress; // 시군구 주소
+    private String provinceName; // 시도 명칭
+    private String lastUpdatedDate; // 최종작성일
+    private String category; // 여가활동
+    private int classDuration; // 클래스 시간
+    private int totalCost; // 클래스 요금
+    private String classParticipants; // 클래스 인원
+    private String curriculum; // 클래스 커리큘럼
+    private String classTitle; // 클래스 타이틀
+
+
+    public static HobbyDto of(String legalTownName, String cityDistrictName, String cityDistrictAddress, String provinceName, String lastUpdatedDate, String category, int classDuration, int totalCost, String classParticipants, String curriculum, String classTitle) {
+        return HobbyDto.builder()
+                .legalTownName(legalTownName)
+                .cityDistrictName(cityDistrictName)
+                .cityDistrictAddress(cityDistrictAddress)
+                .provinceName(provinceName)
+                .lastUpdatedDate(lastUpdatedDate)
+                .category(category)
+                .classDuration(classDuration)
+                .totalCost(totalCost)
+                .classParticipants(classParticipants)
+                .curriculum(curriculum)
+                .classTitle(classTitle)
+                .build();
+    }
+
+}

--- a/src/main/java/com/reborn/server/domain/hobby/dto/response/HobbyResponse.java
+++ b/src/main/java/com/reborn/server/domain/hobby/dto/response/HobbyResponse.java
@@ -1,0 +1,35 @@
+package com.reborn.server.domain.hobby.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class HobbyResponse {
+    private Long id;
+    private String cityDistrictName; // 시군구 명칭
+    private String provinceName; // 시도 명칭
+    private String category; // 카테고리
+    private int classDuration; // 클래스 시간
+    private int totalCost; // 클래스 요금
+    private String classParticipants; // 클래스 인원
+    private String curriculum; // 클래스 커리큘럼
+    private String classTitle; // 클래스 타이틀
+
+
+    public static HobbyResponse of(Long id, String cityDistrictName, String provinceName, String category, int classDuration, int totalCost, String classParticipants, String curriculum, String classTitle) {
+        return HobbyResponse.builder()
+                .id(id)
+                .cityDistrictName(cityDistrictName)
+                .provinceName(provinceName)
+                .category(category)
+                .classDuration(classDuration)
+                .totalCost(totalCost)
+                .classParticipants(classParticipants)
+                .curriculum(curriculum)
+                .classTitle(classTitle)
+                .build();
+    }
+}

--- a/src/main/java/com/reborn/server/domain/hobby/infra/HobbyApiClient.java
+++ b/src/main/java/com/reborn/server/domain/hobby/infra/HobbyApiClient.java
@@ -1,0 +1,108 @@
+package com.reborn.server.domain.hobby.infra;
+
+import com.reborn.server.domain.hobby.application.HobbyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class HobbyApiClient {
+
+    private final HobbyService hobbyService;
+
+    @Value("${openApi.service-key}")
+    private String serviceKey;
+
+    @Value("${openApi.url}")
+    private String url;
+
+    @GetMapping("/fetch-hobbies")
+    public ResponseEntity<String> callHobbyApi() {
+        HttpURLConnection urlConnection = null;
+        InputStream stream = null;
+        String result = null;
+        int currentCount;
+        boolean hasDataMore = true;
+
+        int perPage = 1000; // 페이지당 데이터 수
+        int page = 1;
+
+
+        while (hasDataMore) {
+            String urlStr = url +
+                    "page=" + page +
+                    "&perPage=" + perPage +
+                    "&serviceKey=" + serviceKey;
+
+            try {
+                URL url = new URL(urlStr);
+
+                urlConnection = (HttpURLConnection) url.openConnection();
+                stream = getNetworkConnection(urlConnection);
+                result = readStreamToString(stream);
+
+                if (stream != null) stream.close();
+
+                currentCount = hobbyService.parseHobbyDtosAndSave(result);
+
+                if (currentCount < perPage)
+                    hasDataMore = false;
+
+                page++;
+
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally {
+                if (urlConnection != null) {
+                    urlConnection.disconnect();
+                }
+            }
+        }
+
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+
+    /* URLConnection 을 전달받아 연결정보 설정 후 연결, 연결 후 수신한 InputStream 반환 */
+    private InputStream getNetworkConnection(HttpURLConnection urlConnection) throws IOException {
+        urlConnection.setConnectTimeout(3000);
+        urlConnection.setReadTimeout(3000);
+        urlConnection.setRequestMethod("GET");
+        urlConnection.setDoInput(true);
+
+        if (urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+            throw new IOException("HTTP error code : " + urlConnection.getResponseCode());
+        }
+
+        return urlConnection.getInputStream();
+    }
+
+    /* InputStream을 전달받아 문자열로 변환 후 반환 */
+    private String readStreamToString(InputStream stream) throws IOException {
+        StringBuilder result = new StringBuilder();
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+
+        String readLine;
+        while ((readLine = br.readLine()) != null) {
+            result.append(readLine + "\n\r");
+        }
+
+        br.close();
+
+        return result.toString();
+    }
+}


### PR DESCRIPTION
🐣Title
feat: [Hobby] open api DB 저장 & 프론트 반환

🐣Part
BE

🐣Key Changes
infra : open api 데이터 로컬 DB에 저장
domain, dao, dto, application 작성
프론트 반환 api 구현

🐣To Reviewer
임시로 정한 open api 데이터 class title을 유니크키로 두고 로컬 DB에 저장함
아직 api 확정 전 < domain, dto 변경될 듯 & json 파싱하고 DB 저장하는 코드 그대로 활용 위함
DB의 데이터 아직 프론트에서 뭐가 필요할지 모르겠어서 내 맘대로 적당히 반환 ㅎㅎ

🐣Next
패키지 구조 고민
api data 한 번에  패치해오는 과정 좀 더 고민
api 문제해결 혹은 다시 다른 거 찾아오기,,,
프론트 반환 data 회의 후 확정